### PR TITLE
Add static export and new sections

### DIFF
--- a/my-personal-site/app/page.tsx
+++ b/my-personal-site/app/page.tsx
@@ -1,61 +1,21 @@
-'use client';
-
-import Image from 'next/image';
-import { useState } from 'react';
-import ProjectCard from '../components/ProjectCard';
-import projects from '../components/projectsData';
+import Header from '../components/Header';
+import Hero from '../components/Hero';
+import About from '../components/About';
+import Timeline from '../components/Timeline';
+import Skills from '../components/Skills';
+import ProjectsSection from '../components/ProjectsSection';
+import Contact from '../components/Contact';
 
 export default function Home() {
-  const [showMore, setShowMore] = useState(false);
-
   return (
-    <main className="flex flex-col items-center justify-center">
-      <section className="min-h-screen flex flex-col items-center justify-center text-center p-8">
-        <h1 className="text-5xl font-bold mb-4">Hola, soy Antonio</h1>
-        <p className="text-xl mb-6">Desarrollador Web apasionado por la tecnología</p>
-        <button
-          className="px-6 py-3 bg-foreground text-background rounded hover:opacity-80 transition"
-          onClick={() => document.getElementById('about')?.scrollIntoView({ behavior: 'smooth' })}
-        >
-          Conóceme
-        </button>
-      </section>
-
-      <section id="about" className="max-w-2xl w-full px-4 py-20 text-center">
-        <h2 className="text-3xl font-semibold mb-4">Acerca de mí</h2>
-        <p className="mb-4">
-          {showMore
-            ? 'Soy un desarrollador con experiencia en múltiples tecnologías y me encanta crear aplicaciones web modernas e interactivas.'
-            : 'Soy un desarrollador con experiencia en múltiples tecnologías.'}
-        </p>
-        <button
-          className="text-blue-600 underline"
-          onClick={() => setShowMore(!showMore)}
-        >
-          Mostrar {showMore ? 'menos' : 'más'}
-        </button>
-      </section>
-
-      <section id="projects" className="w-full px-4 py-20 bg-gray-100 dark:bg-gray-900">
-        <h2 className="text-3xl font-semibold text-center mb-8">Proyectos</h2>
-        <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3 max-w-6xl mx-auto">
-          {projects.map((project) => (
-            <ProjectCard key={project.title} project={project} />
-          ))}
-        </div>
-      </section>
-
-      <section id="contact" className="max-w-lg w-full px-4 py-20 text-center">
-        <h2 className="text-3xl font-semibold mb-4">Contacto</h2>
-        <form className="space-y-4">
-          <input className="w-full border rounded p-2" type="text" placeholder="Nombre" />
-          <input className="w-full border rounded p-2" type="email" placeholder="Correo" />
-          <textarea className="w-full border rounded p-2" rows={4} placeholder="Mensaje" />
-          <button type="submit" className="px-6 py-2 bg-foreground text-background rounded hover:opacity-80 transition">
-            Enviar
-          </button>
-        </form>
-      </section>
+    <main className="flex flex-col items-center">
+      <Header />
+      <Hero />
+      <About />
+      <Timeline />
+      <Skills />
+      <ProjectsSection />
+      <Contact />
     </main>
   );
 }

--- a/my-personal-site/components/About.tsx
+++ b/my-personal-site/components/About.tsx
@@ -1,0 +1,11 @@
+export default function About() {
+  return (
+    <section id="about" className="max-w-2xl mx-auto px-4 py-20 text-center">
+      <h2 className="text-3xl font-semibold mb-4">Acerca de mí</h2>
+      <p className="mb-4">
+        Soy un desarrollador con experiencia en múltiples tecnologías y me encanta crear
+        aplicaciones web modernas e interactivas.
+      </p>
+    </section>
+  );
+}

--- a/my-personal-site/components/Contact.tsx
+++ b/my-personal-site/components/Contact.tsx
@@ -1,0 +1,15 @@
+export default function Contact() {
+  return (
+    <section id="contact" className="max-w-lg mx-auto px-4 py-20 text-center">
+      <h2 className="text-3xl font-semibold mb-4">Contacto</h2>
+      <form className="space-y-4">
+        <input className="w-full border rounded p-2" type="text" placeholder="Nombre" />
+        <input className="w-full border rounded p-2" type="email" placeholder="Correo" />
+        <textarea className="w-full border rounded p-2" rows={4} placeholder="Mensaje" />
+        <button type="submit" className="px-6 py-2 bg-foreground text-background rounded hover:opacity-80 transition">
+          Enviar
+        </button>
+      </form>
+    </section>
+  );
+}

--- a/my-personal-site/components/Header.tsx
+++ b/my-personal-site/components/Header.tsx
@@ -1,0 +1,19 @@
+import Link from 'next/link';
+
+export default function Header() {
+  return (
+    <header className="w-full fixed top-0 left-0 bg-background/80 backdrop-blur z-10">
+      <nav className="max-w-5xl mx-auto flex justify-between items-center p-4">
+        <span className="font-bold">Mi Sitio</span>
+        <ul className="flex space-x-4 text-sm">
+          <li><Link href="#hero">Inicio</Link></li>
+          <li><Link href="#about">Sobre mí</Link></li>
+          <li><Link href="#timeline">Experiencia</Link></li>
+          <li><Link href="#skills">Habilidades</Link></li>
+          <li><Link href="#projects">Proyectos</Link></li>
+          <li><Link href="#contact">Contacto</Link></li>
+        </ul>
+      </nav>
+    </header>
+  );
+}

--- a/my-personal-site/components/Hero.tsx
+++ b/my-personal-site/components/Hero.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+export default function Hero() {
+
+  return (
+    <section id="hero" className="min-h-screen flex flex-col items-center justify-center text-center p-8">
+      <h1 className="text-5xl font-bold mb-4">Hola, soy Antonio</h1>
+      <p className="text-xl mb-6">Desarrollador Web apasionado por la tecnología</p>
+      <button
+        className="px-6 py-3 bg-foreground text-background rounded hover:opacity-80 transition"
+        onClick={() => document.getElementById('about')?.scrollIntoView({ behavior: 'smooth' })}
+      >
+        Conóceme
+      </button>
+    </section>
+  );
+}

--- a/my-personal-site/components/ProjectsSection.tsx
+++ b/my-personal-site/components/ProjectsSection.tsx
@@ -1,0 +1,15 @@
+import ProjectCard from './ProjectCard';
+import projects from './projectsData';
+
+export default function ProjectsSection() {
+  return (
+    <section id="projects" className="w-full px-4 py-20 bg-gray-100 dark:bg-gray-900">
+      <h2 className="text-3xl font-semibold text-center mb-8">Proyectos</h2>
+      <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3 max-w-6xl mx-auto">
+        {projects.map((project) => (
+          <ProjectCard key={project.title} project={project} />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/my-personal-site/components/Skills.tsx
+++ b/my-personal-site/components/Skills.tsx
@@ -1,0 +1,19 @@
+export default function Skills() {
+  const skills = ['JavaScript', 'TypeScript', 'React', 'Next.js', 'Tailwind CSS'];
+
+  return (
+    <section id="skills" className="max-w-3xl mx-auto px-4 py-20 text-center">
+      <h2 className="text-3xl font-semibold mb-8">Habilidades</h2>
+      <ul className="flex flex-wrap justify-center gap-4">
+        {skills.map((skill) => (
+          <li
+            key={skill}
+            className="px-4 py-2 border rounded-full bg-background shadow"
+          >
+            {skill}
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/my-personal-site/components/Timeline.tsx
+++ b/my-personal-site/components/Timeline.tsx
@@ -1,0 +1,19 @@
+export default function Timeline() {
+  return (
+    <section id="timeline" className="w-full bg-gray-100 dark:bg-gray-900 py-20">
+      <div className="max-w-3xl mx-auto px-4">
+        <h2 className="text-3xl font-semibold text-center mb-8">Experiencia</h2>
+        <ul className="space-y-6">
+          <li className="border-l-2 border-foreground pl-4">
+            <h3 className="font-bold">2024 - Empresa A</h3>
+            <p>Desarrollador Frontend</p>
+          </li>
+          <li className="border-l-2 border-foreground pl-4">
+            <h3 className="font-bold">2022 - Empresa B</h3>
+            <p>Ingeniero de Software</p>
+          </li>
+        </ul>
+      </div>
+    </section>
+  );
+}

--- a/my-personal-site/next.config.ts
+++ b/my-personal-site/next.config.ts
@@ -1,7 +1,7 @@
-import type { NextConfig } from "next";
+import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  output: 'export',
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- implement Header, Hero, About, Timeline, Skills, ProjectsSection and Contact components
- update the home page to assemble new sections
- enable static export in Next config

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68848aeae8d0832c83c15317e6c5aa14