### PR TITLE
Set up GitHub Pages deployment

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -1,0 +1,30 @@
+name: Deploy Next.js site to GitHub Pages
+
+on:
+  push:
+    branches: ["main"]
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: my-personal-site/package-lock.json
+      - run: npm ci
+        working-directory: my-personal-site
+      - run: npm run build
+        working-directory: my-personal-site
+      - run: touch out/.nojekyll
+        working-directory: my-personal-site
+      - uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          branch: gh-pages
+          folder: my-personal-site/out
+          clean: true

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 .next/
 .env
 .DS_Store
+my-personal-site/out/

--- a/my-personal-site/next.config.ts
+++ b/my-personal-site/next.config.ts
@@ -2,6 +2,8 @@ import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
   output: 'export',
+  basePath: '/antoniohc',
+  assetPrefix: '/antoniohc',
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- set `basePath` and `assetPrefix` to `/antoniohc`
- add workflow to deploy the exported site to `gh-pages`
- ignore the build output directory

## Testing
- `npm ci`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68848df228e4832c86b26f175443e0d8