### PR TITLE
Enhance portfolio with dark mode and animations

### DIFF
--- a/my-personal-site/components/DarkModeToggle.tsx
+++ b/my-personal-site/components/DarkModeToggle.tsx
@@ -1,0 +1,44 @@
+'use client';
+import { useEffect, useState } from 'react';
+
+export default function DarkModeToggle() {
+  const [dark, setDark] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const saved = localStorage.getItem('theme');
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    const initialDark = saved ? saved === 'dark' : prefersDark;
+    setDark(initialDark);
+    applyTheme(initialDark);
+  }, []);
+
+  const applyTheme = (isDark: boolean) => {
+    const root = document.documentElement;
+    if (isDark) {
+      root.style.setProperty('--background', '#0a0a0a');
+      root.style.setProperty('--foreground', '#ededed');
+      localStorage.setItem('theme', 'dark');
+    } else {
+      root.style.setProperty('--background', '#ffffff');
+      root.style.setProperty('--foreground', '#171717');
+      localStorage.setItem('theme', 'light');
+    }
+  };
+
+  const toggleTheme = () => {
+    const next = !dark;
+    setDark(next);
+    applyTheme(next);
+  };
+
+  return (
+    <button
+      aria-label="Toggle dark mode"
+      onClick={toggleTheme}
+      className="p-2 text-xl"
+    >
+      {dark ? '☀️' : '🌙'}
+    </button>
+  );
+}

--- a/my-personal-site/components/Header.tsx
+++ b/my-personal-site/components/Header.tsx
@@ -1,17 +1,30 @@
+'use client';
+import { useState } from 'react';
 import Link from 'next/link';
+import DarkModeToggle from './DarkModeToggle';
 
 export default function Header() {
+  const [open, setOpen] = useState(false);
+
+  const toggleMenu = () => setOpen(!open);
+
   return (
     <header className="w-full fixed top-0 left-0 bg-background/80 backdrop-blur z-10">
-      <nav className="max-w-5xl mx-auto flex justify-between items-center p-4">
+      <nav className="max-w-5xl mx-auto flex items-center justify-between p-4 relative">
         <span className="font-bold">Mi Sitio</span>
-        <ul className="flex space-x-4 text-sm">
-          <li><Link href="#hero">Inicio</Link></li>
-          <li><Link href="#about">Sobre mí</Link></li>
-          <li><Link href="#timeline">Experiencia</Link></li>
-          <li><Link href="#skills">Habilidades</Link></li>
-          <li><Link href="#projects">Proyectos</Link></li>
-          <li><Link href="#contact">Contacto</Link></li>
+        <button className="md:hidden text-2xl" onClick={toggleMenu} aria-label="Toggle menu">
+          ☰
+        </button>
+        <ul
+          className={`absolute md:static top-full left-0 right-0 bg-background md:bg-transparent shadow md:shadow-none p-4 md:p-0 flex flex-col md:flex-row items-start md:items-center space-y-2 md:space-y-0 md:space-x-4 text-sm ${open ? 'block' : 'hidden'} md:block`}
+        >
+          <li><Link href="#hero" onClick={() => setOpen(false)}>Inicio</Link></li>
+          <li><Link href="#about" onClick={() => setOpen(false)}>Sobre mí</Link></li>
+          <li><Link href="#timeline" onClick={() => setOpen(false)}>Experiencia</Link></li>
+          <li><Link href="#skills" onClick={() => setOpen(false)}>Habilidades</Link></li>
+          <li><Link href="#projects" onClick={() => setOpen(false)}>Proyectos</Link></li>
+          <li><Link href="#contact" onClick={() => setOpen(false)}>Contacto</Link></li>
+          <li className="md:ml-4"><DarkModeToggle /></li>
         </ul>
       </nav>
     </header>

--- a/my-personal-site/components/Hero.tsx
+++ b/my-personal-site/components/Hero.tsx
@@ -1,17 +1,23 @@
 'use client';
+import { motion } from 'framer-motion';
 
 export default function Hero() {
-
   return (
-    <section id="hero" className="min-h-screen flex flex-col items-center justify-center text-center p-8">
-      <h1 className="text-5xl font-bold mb-4">Hola, soy Antonio</h1>
-      <p className="text-xl mb-6">Desarrollador Web apasionado por la tecnología</p>
+    <motion.section
+      id="hero"
+      className="min-h-screen flex flex-col items-center justify-center text-center p-8"
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.6 }}
+    >
+      <h1 className="text-5xl md:text-6xl font-bold mb-4">Hola, soy Antonio</h1>
+      <p className="text-xl md:text-2xl mb-6">Desarrollador Web apasionado por la tecnología</p>
       <button
         className="px-6 py-3 bg-foreground text-background rounded hover:opacity-80 transition"
         onClick={() => document.getElementById('about')?.scrollIntoView({ behavior: 'smooth' })}
       >
         Conóceme
       </button>
-    </section>
+    </motion.section>
   );
 }

--- a/my-personal-site/components/ProjectsSection.tsx
+++ b/my-personal-site/components/ProjectsSection.tsx
@@ -1,3 +1,5 @@
+'use client';
+import { motion } from 'framer-motion';
 import ProjectCard from './ProjectCard';
 import projects from './projectsData';
 
@@ -7,7 +9,16 @@ export default function ProjectsSection() {
       <h2 className="text-3xl font-semibold text-center mb-8">Proyectos</h2>
       <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3 max-w-6xl mx-auto">
         {projects.map((project) => (
-          <ProjectCard key={project.title} project={project} />
+          <motion.div
+            key={project.title}
+            className="transform transition-transform hover:scale-105"
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            transition={{ duration: 0.5 }}
+          >
+            <ProjectCard project={project} />
+          </motion.div>
         ))}
       </div>
     </section>

--- a/my-personal-site/components/Timeline.tsx
+++ b/my-personal-site/components/Timeline.tsx
@@ -1,17 +1,30 @@
+'use client';
+import { motion } from 'framer-motion';
+
 export default function Timeline() {
+  const items = [
+    { year: '2024 - Empresa A', role: 'Desarrollador Frontend' },
+    { year: '2022 - Empresa B', role: 'Ingeniero de Software' },
+  ];
+
   return (
     <section id="timeline" className="w-full bg-gray-100 dark:bg-gray-900 py-20">
       <div className="max-w-3xl mx-auto px-4">
         <h2 className="text-3xl font-semibold text-center mb-8">Experiencia</h2>
         <ul className="space-y-6">
-          <li className="border-l-2 border-foreground pl-4">
-            <h3 className="font-bold">2024 - Empresa A</h3>
-            <p>Desarrollador Frontend</p>
-          </li>
-          <li className="border-l-2 border-foreground pl-4">
-            <h3 className="font-bold">2022 - Empresa B</h3>
-            <p>Ingeniero de Software</p>
-          </li>
+          {items.map((item) => (
+            <motion.li
+              key={item.year}
+              className="border-l-2 border-foreground pl-4"
+              initial={{ opacity: 0, x: -50 }}
+              whileInView={{ opacity: 1, x: 0 }}
+              viewport={{ once: true, amount: 0.5 }}
+              transition={{ duration: 0.5 }}
+            >
+              <h3 className="font-bold">{item.year}</h3>
+              <p>{item.role}</p>
+            </motion.li>
+          ))}
         </ul>
       </div>
     </section>

--- a/my-personal-site/package-lock.json
+++ b/my-personal-site/package-lock.json
@@ -8,6 +8,7 @@
       "name": "my-personal-site",
       "version": "0.1.0",
       "dependencies": {
+        "framer-motion": "^12.23.9",
         "next": "15.3.3",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
@@ -1098,6 +1099,33 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.23.9",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.23.9.tgz",
+      "integrity": "sha512-TqEHXj8LWfQSKqfdr5Y4mYltYLw96deu6/K9kGDd+ysqRJPNwF9nb5mZcrLmybHbU7gcJ+HQar41U3UTGanbbQ==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.23.9",
+        "motion-utils": "^12.23.6",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -1409,6 +1437,21 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.23.9",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.23.9.tgz",
+      "integrity": "sha512-6Sv++iWS8XMFCgU1qwKj9l4xuC47Hp4+2jvPfyTXkqDg2tTzSgX6nWKD4kNFXk0k7llO59LZTPuJigza4A2K1A==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.23.6"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.23.6",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.23.6.tgz",
+      "integrity": "sha512-eAWoPgr4eFEOFfg2WjIsMoqJTW6Z8MTUCgn/GZ3VRpClWBdnbjryiA3ZSNLyxCTmCQx4RmYX6jX1iWHbenUPNQ==",
+      "license": "MIT"
     },
     "node_modules/nanoid": {
       "version": "3.3.11",

--- a/my-personal-site/package.json
+++ b/my-personal-site/package.json
@@ -9,16 +9,17 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "framer-motion": "^12.23.9",
+    "next": "15.3.3",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0",
-    "next": "15.3.3"
+    "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "typescript": "^5",
+    "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
-    "@tailwindcss/postcss": "^4",
-    "tailwindcss": "^4"
+    "tailwindcss": "^4",
+    "typescript": "^5"
   }
 }


### PR DESCRIPTION
## Summary
- add `framer-motion` dependency
- implement `DarkModeToggle` component to switch themes
- integrate toggle in the responsive navigation bar
- animate hero, timeline items and project cards

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6885d45bde50832cb5c87d531d1db6da