### PR TITLE
fix: wrap parallax and animated components with dynamic client-only imports

### DIFF
--- a/my-personal-site/app/layout.tsx
+++ b/my-personal-site/app/layout.tsx
@@ -1,8 +1,18 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
-import AnimatedBackground from "../components/AnimatedBackground";
-import { ParallaxProvider } from "react-scroll-parallax";
+import dynamic from "next/dynamic";
+
+const ParallaxProvider = dynamic(
+  () =>
+    import("react-scroll-parallax").then((m) => m.ParallaxProvider),
+  { ssr: false }
+);
+
+const AnimatedBackground = dynamic(
+  () => import("../components/AnimatedBackground"),
+  { ssr: false }
+);
 
 const geistSans = Geist({
   variable: "--font-geist-sans",

--- a/my-personal-site/app/page.tsx
+++ b/my-personal-site/app/page.tsx
@@ -5,7 +5,12 @@ import Timeline from '../components/Timeline';
 import Skills from '../components/Skills';
 import ProjectsSection from '../components/ProjectsSection';
 import Contact from '../components/Contact';
-import ParallaxSection from '../components/ParallaxSection';
+import dynamic from 'next/dynamic';
+
+const ParallaxSection = dynamic(
+  () => import('../components/ParallaxSection'),
+  { ssr: false }
+);
 
 export default function Home() {
   return (


### PR DESCRIPTION
## Summary
- use dynamic imports with `ssr: false` for `ParallaxProvider` and `AnimatedBackground`
- use dynamic import with `ssr: false` for `ParallaxSection`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6887048b2bb8832caf849d5fbf895d8d