### PR TITLE
fix: mover proveedores a componente cliente para resolver error de ssr

### DIFF
--- a/my-personal-site/app/layout.tsx
+++ b/my-personal-site/app/layout.tsx
@@ -1,18 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
-import dynamic from "next/dynamic";
-
-const ParallaxProvider = dynamic(
-  () =>
-    import("react-scroll-parallax").then((m) => m.ParallaxProvider),
-  { ssr: false }
-);
-
-const AnimatedBackground = dynamic(
-  () => import("../components/AnimatedBackground"),
-  { ssr: false }
-);
+import Providers from "../components/Providers";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -37,10 +26,9 @@ export default function RootLayout({
   return (
     <html lang="es">
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
-        <ParallaxProvider>
-          <AnimatedBackground />
+        <Providers>
           {children}
-        </ParallaxProvider>
+        </Providers>
       </body>
     </html>
   );

--- a/my-personal-site/app/page.tsx
+++ b/my-personal-site/app/page.tsx
@@ -5,12 +5,7 @@ import Timeline from '../components/Timeline';
 import Skills from '../components/Skills';
 import ProjectsSection from '../components/ProjectsSection';
 import Contact from '../components/Contact';
-import dynamic from 'next/dynamic';
-
-const ParallaxSection = dynamic(
-  () => import('../components/ParallaxSection'),
-  { ssr: false }
-);
+import ParallaxSection from '../components/ParallaxSection';
 
 export default function Home() {
   return (

--- a/my-personal-site/components/Providers.tsx
+++ b/my-personal-site/components/Providers.tsx
@@ -1,0 +1,14 @@
+'use client';
+
+import { ReactNode } from 'react';
+import { ParallaxProvider } from 'react-scroll-parallax';
+import AnimatedBackground from './AnimatedBackground';
+
+export default function Providers({ children }: { children: ReactNode }) {
+  return (
+    <ParallaxProvider>
+      <AnimatedBackground />
+      {children}
+    </ParallaxProvider>
+  );
+}


### PR DESCRIPTION
## Summary
- wrap ParallaxProvider and AnimatedBackground in a new client component `Providers`
- use `Providers` in layout
- statically import `ParallaxSection`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688708828828832cb416c79deb307e6b