### PR TITLE
feat: rellenar contenido real y añadir sección de educación

### DIFF
--- a/my-personal-site/app/page.tsx
+++ b/my-personal-site/app/page.tsx
@@ -2,6 +2,7 @@ import Header from '../components/Header';
 import Hero from '../components/Hero';
 import About from '../components/About';
 import Timeline from '../components/Timeline';
+import Education from '../components/Education';
 import Skills from '../components/Skills';
 import ProjectsSection from '../components/ProjectsSection';
 import Contact from '../components/Contact';
@@ -17,6 +18,9 @@ export default function Home() {
       </ParallaxSection>
       <ParallaxSection speed={-5}>
         <Timeline />
+      </ParallaxSection>
+      <ParallaxSection speed={-7}>
+        <Education />
       </ParallaxSection>
       <ParallaxSection speed={-10}>
         <Skills />

--- a/my-personal-site/components/About.tsx
+++ b/my-personal-site/components/About.tsx
@@ -3,8 +3,12 @@ export default function About() {
     <section id="about" className="max-w-2xl mx-auto px-4 py-20 text-center">
       <h2 className="text-3xl font-semibold mb-4">Acerca de mí</h2>
       <p className="mb-4">
-        Soy un desarrollador con experiencia en múltiples tecnologías y me encanta crear
-        aplicaciones web modernas e interactivas.
+        Soy Ingeniero en Informática y en Ingeniería Técnica de Sistemas. A lo largo
+        de mi trayectoria he evolucionado hacia el liderazgo técnico, coordinando
+        equipos de desarrollo y dirigiendo grandes proyectos de software. Domino
+        tecnologías frontend como HTML/HTML5, CSS/Sass, JavaScript/ES6+, React/Redux
+        y Node.js. Además, soy especialista en usabilidad, SEO y responsive design,
+        integrando herramientas de IA como GitHub Copilot de forma coordinada y escalable.
       </p>
     </section>
   );

--- a/my-personal-site/components/Education.tsx
+++ b/my-personal-site/components/Education.tsx
@@ -1,0 +1,44 @@
+'use client';
+import { motion } from 'framer-motion';
+
+export default function Education() {
+  const studies = [
+    {
+      title: 'Grado en Ingeniería Informática',
+      institution: 'Universidad de Castilla-La Mancha',
+      date: '2010 – 2012',
+    },
+    {
+      title: 'Máster en Tecnologías Web, IT',
+      institution: 'Universidad de Castilla-La Mancha',
+      date: '2009 – 2010',
+    },
+    {
+      title: 'Ingeniería Técnica en Informática de Sistemas',
+      institution: 'Universidad de Almería',
+      date: '2005 – 2009',
+    },
+  ];
+
+  return (
+    <section id="education" className="max-w-3xl mx-auto px-4 py-20">
+      <h2 className="text-3xl font-semibold text-center mb-8">Educación</h2>
+      <ul className="space-y-6">
+        {studies.map((study) => (
+          <motion.li
+            key={study.title}
+            className="border-l-2 border-foreground pl-4"
+            initial={{ opacity: 0, x: -50 }}
+            whileInView={{ opacity: 1, x: 0 }}
+            viewport={{ once: true, amount: 0.5 }}
+            transition={{ duration: 0.5 }}
+          >
+            <h3 className="font-bold">{study.title}</h3>
+            <p className="italic">{study.institution}</p>
+            <span className="text-sm text-gray-500 dark:text-gray-400">{study.date}</span>
+          </motion.li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/my-personal-site/components/Header.tsx
+++ b/my-personal-site/components/Header.tsx
@@ -21,6 +21,7 @@ export default function Header() {
           <li><Link href="#hero" onClick={() => setOpen(false)}>Inicio</Link></li>
           <li><Link href="#about" onClick={() => setOpen(false)}>Sobre mí</Link></li>
           <li><Link href="#timeline" onClick={() => setOpen(false)}>Experiencia</Link></li>
+          <li><Link href="#education" onClick={() => setOpen(false)}>Educación</Link></li>
           <li><Link href="#skills" onClick={() => setOpen(false)}>Habilidades</Link></li>
           <li><Link href="#projects" onClick={() => setOpen(false)}>Proyectos</Link></li>
           <li><Link href="#contact" onClick={() => setOpen(false)}>Contacto</Link></li>

--- a/my-personal-site/components/Hero.tsx
+++ b/my-personal-site/components/Hero.tsx
@@ -4,7 +4,11 @@ import { useTypewriter, Cursor } from 'react-simple-typewriter';
 
 export default function Hero() {
   const [text] = useTypewriter({
-    words: ['Desarrollador Web', 'Ingeniero de software', 'Apasionado por la tecnología'],
+    words: [
+      'Lidero equipos de desarrollo',
+      'Domino tecnologías web',
+      'Integro IA con GitHub Copilot',
+    ],
     loop: 0,
   });
   return (
@@ -15,7 +19,8 @@ export default function Hero() {
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.6 }}
     >
-      <h1 className="text-5xl md:text-6xl font-bold mb-4">Hola, soy Antonio</h1>
+      <h1 className="text-5xl md:text-6xl font-bold mb-4">Hola, soy Antonio Hernández Cervantes</h1>
+      <h2 className="text-2xl md:text-3xl mb-2">Líder Técnico y experto en integración de IA</h2>
       <p className="text-xl md:text-2xl mb-6">
         <span>{text}</span>
         <Cursor cursorStyle="|" />

--- a/my-personal-site/components/Skills.tsx
+++ b/my-personal-site/components/Skills.tsx
@@ -9,6 +9,9 @@ export default function Skills() {
     { name: 'React', level: 88 },
     { name: 'Next.js', level: 80 },
     { name: 'Tailwind CSS', level: 75 },
+    { name: 'Liderazgo y gestión de equipos', level: 90 },
+    { name: 'Integración de IA en proyectos', level: 85 },
+    { name: 'Estrategia con GitHub Copilot', level: 80 },
   ];
 
   return (

--- a/my-personal-site/components/Timeline.tsx
+++ b/my-personal-site/components/Timeline.tsx
@@ -3,8 +3,48 @@ import { motion } from 'framer-motion';
 
 export default function Timeline() {
   const items = [
-    { year: '2024 - Empresa A', role: 'Desarrollador Frontend' },
-    { year: '2022 - Empresa B', role: 'Ingeniero de Software' },
+    {
+      title: 'Líder Técnico / Analista sénior',
+      subtitle: 'Bahía Software',
+      description: 'Gestión de equipos de desarrollo y dirección técnica de proyectos de software.',
+      date: 'nov. 2021 – actualidad',
+    },
+    {
+      title: 'Programador Frontend Senior',
+      subtitle: 'intercaso',
+      description: 'Desarrollo de aplicaciones frontend con React, Redux y tecnologías modernas.',
+      date: 'sept. 2017 – oct. 2021',
+    },
+    {
+      title: 'CTO · Programador Senior Frontend Web',
+      subtitle: 'Deddian Technology',
+      description: 'Responsable del desarrollo frontend de proyectos web.',
+      date: 'ene. 2016 – ago. 2017',
+    },
+    {
+      title: 'Profesor del Máster en Tecnologías Web',
+      subtitle: 'UCLM',
+      description: 'Docente de asignaturas como CSS, JavaScript, AJAX y ASP.NET.',
+      date: 'nov. 2010 – nov. 2016',
+    },
+    {
+      title: 'Analista/Desarrollador Tecnologías Web',
+      subtitle: 'Marpadal Interactive Media',
+      description: 'Desarrollo de proyectos web en Albacete.',
+      date: 'jun. 2013 – dic. 2015',
+    },
+    {
+      title: 'Analista/Desarrollador de proyectos en I+D',
+      subtitle: 'ISE Research',
+      description: 'Proyectos de investigación y desarrollo.',
+      date: 'may. 2011 – jun. 2013',
+    },
+    {
+      title: 'Tecnólogo',
+      subtitle: 'ISE Research',
+      description: 'Desarrollo de proyectos en I+D.',
+      date: 'dic. 2009 – may. 2011',
+    },
   ];
 
   return (
@@ -14,15 +54,17 @@ export default function Timeline() {
         <ul className="space-y-6">
           {items.map((item) => (
             <motion.li
-              key={item.year}
+              key={item.title}
               className="border-l-2 border-foreground pl-4"
               initial={{ opacity: 0, x: -50 }}
               whileInView={{ opacity: 1, x: 0 }}
               viewport={{ once: true, amount: 0.5 }}
               transition={{ duration: 0.5 }}
             >
-              <h3 className="font-bold">{item.year}</h3>
-              <p>{item.role}</p>
+              <h3 className="font-bold">{item.title}</h3>
+              <p className="italic">{item.subtitle}</p>
+              <p>{item.description}</p>
+              <span className="text-sm text-gray-500 dark:text-gray-400">{item.date}</span>
             </motion.li>
           ))}
         </ul>

--- a/my-personal-site/components/projectsData.ts
+++ b/my-personal-site/components/projectsData.ts
@@ -19,6 +19,12 @@ const projects: Project[] = [
     imageUrl: 'https://source.unsplash.com/random/800x600?sig=3',
     url: '#',
   },
+  {
+    title: 'Kuicco',
+    description: 'Plataforma de almacenamiento seguro desarrollada junto a Deddian Technology.',
+    imageUrl: 'https://source.unsplash.com/random/800x600?sig=4',
+    url: '#',
+  },
 ];
 
 export default projects;


### PR DESCRIPTION
## Summary
- update hero heading and typewriter text
- replace about paragraph with real bio
- fill timeline experience items
- add new education section
- add leadership and AI skills
- mention Kuicco project
- render education component and link in header

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68884409510c832c8eee4cf322a943af