### PR TITLE
Ajustar header y menú a pantalla completa

### DIFF
--- a/my-personal-site/components/DrawerMenu.tsx
+++ b/my-personal-site/components/DrawerMenu.tsx
@@ -24,43 +24,29 @@ export default function DrawerMenu({ open, onClose }: DrawerProps) {
   return (
     <AnimatePresence>
       {open && (
-        <>
-          {/* Backdrop */}
-          <motion.div
-            className="fixed inset-0 bg-black/50 z-40"
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-            onClick={onClose}
-          />
-          {/* Panel */}
-          <motion.aside
-            className="fixed right-0 top-0 bottom-0 w-72 bg-background z-50 shadow-xl flex flex-col"
-            initial={{ x: '100%' }}
-            animate={{ x: 0 }}
-            exit={{ x: '100%' }}
-            transition={{ type: 'tween', duration: 0.35 }}
-          >
-            <nav className="flex-1 overflow-y-auto py-8">
-              <ul className="space-y-4 px-6">
-                {links.map(({ href, label, icon: Icon }) => (
-                  <li key={href}>
-                    <Link
-                      href={href}
-                      onClick={onClose}
-                      className={`flex items-center gap-3 text-lg font-medium hover:text-primary transition-colors ${
-                        pathname === href ? 'text-primary' : ''
-                      }`}
-                    >
-                      <Icon size={22} />
-                      {label}
-                    </Link>
-                  </li>
-                ))}
-              </ul>
-            </nav>
-          </motion.aside>
-        </>
+        <motion.nav
+          className="fixed inset-0 z-40 bg-background flex flex-col items-center justify-center"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+        >
+          <ul className="space-y-8 text-2xl font-medium">
+            {links.map(({ href, label, icon: Icon }) => (
+              <li key={href}>
+                <Link
+                  href={href}
+                  onClick={onClose}
+                  className={`flex items-center gap-3 hover:text-primary ${
+                    pathname === href ? 'text-primary' : ''
+                  }`}
+                >
+                  <Icon size={24} />
+                  {label}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </motion.nav>
       )}
     </AnimatePresence>
   );

--- a/my-personal-site/components/Header.tsx
+++ b/my-personal-site/components/Header.tsx
@@ -1,5 +1,4 @@
 'use client';
-import Link from 'next/link';
 import { useState } from 'react';
 import { Menu } from 'lucide-react';
 import DrawerMenu from './DrawerMenu';
@@ -9,11 +8,9 @@ export default function Header() {
   const [isOpen, setIsOpen] = useState(false);
 
   return (
-    <header className="fixed w-full z-30 backdrop-blur-md bg-background/70 shadow-sm">
-      <div className="max-w-6xl mx-auto px-4 py-3 flex items-center justify-between">
-        <Link href="#hero" className="text-xl font-bold">Mi Sitio</Link>
-
-        <div className="flex items-center gap-4">
+    <>
+      <header className="fixed top-0 left-0 w-full z-30">
+        <div className="flex items-center justify-end gap-4 p-4">
           {/* DarkMode toggle */}
           <DarkModeToggle />
 
@@ -21,15 +18,15 @@ export default function Header() {
           <button
             onClick={() => setIsOpen(true)}
             aria-label="Abrir menú"
-            className="p-2 rounded-md border border-primary text-primary hover:bg-primary/10 transition-colors"
+            className="p-2 hover:text-primary"
           >
             <Menu size={22} />
           </button>
         </div>
-      </div>
+      </header>
 
-      {/* Drawer */}
+      {/* Menú a pantalla completa */}
       <DrawerMenu open={isOpen} onClose={() => setIsOpen(false)} />
-    </header>
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- Hacer el header transparente y mostrar solo el switch y el icono de menú
- Reemplazar el drawer lateral por un menú de navegación a pantalla completa

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688df0a651e4832c85bcf391f9059825