### PR TITLE
feat: refine experience timeline layout

### DIFF
--- a/my-personal-site/components/ExperienceTimeline.tsx
+++ b/my-personal-site/components/ExperienceTimeline.tsx
@@ -6,25 +6,28 @@ import { experiences } from '@/data/experience';
 export default function ExperienceTimeline() {
   return (
     <section id="experience" className="relative py-24 bg-gradient-to-b from-background via-background/70 to-background">
-      {/* Línea central */}
-      <motion.div
-        className="absolute left-1/2 -translate-x-1 w-[2px] h-full bg-primary origin-top"
-        initial={{ scaleY: 0 }}
-        whileInView={{ scaleY: 1 }}
-        transition={{ duration: 0.8, ease: 'easeOut' }}
-      />
-      <div className="relative max-w-3xl mx-auto flex flex-col gap-20 px-6">
+      <h2 className="text-3xl md:text-4xl font-bold text-center text-foreground mb-16">
+        Experiencia
+      </h2>
+      <div className="relative max-w-3xl mx-auto flex flex-col gap-28 px-6">
+        {/* Línea central */}
+        <motion.div
+          className="absolute left-1/2 -translate-x-1/2 top-0 w-[2px] h-full bg-primary origin-top"
+          initial={{ scaleY: 0 }}
+          whileInView={{ scaleY: 1 }}
+          transition={{ duration: 0.8, ease: 'easeOut' }}
+        />
         {experiences.map((exp, i) => (
           <motion.div
             key={exp.title}
-            className="relative flex items-start gap-6"
+            className="relative flex flex-col md:flex-row"
             initial={{ opacity: 0, x: 100 }}
             whileInView={{ opacity: 1, x: 0 }}
             transition={{ delay: i * 0.15, duration: 0.6 }}
           >
             {/* Nodo */}
             <motion.span
-              className="z-10 w-6 h-6 rounded-full bg-gradient-to-br from-primary to-primary/40 shadow-lg"
+              className="absolute left-1/2 -translate-x-1/2 top-0 z-10 w-6 h-6 rounded-full bg-gradient-to-br from-primary to-primary/40 shadow-lg"
               animate={{ scale: [1, 1.2, 1] }}
               transition={{ repeat: Infinity, duration: 2 }}
             />
@@ -34,7 +37,7 @@ export default function ExperienceTimeline() {
               tiltMaxAngleY={4}
               glareEnable
               glareMaxOpacity={0.15}
-              className="before:absolute before:left-[-7px] before:top-5 before:border-l-[7px] before:border-l-primary before:border-y-[7px] before:border-y-transparent"
+              className="ml-10 md:ml-14 before:absolute before:left-[-7px] before:top-5 before:border-l-[7px] before:border-l-primary before:border-y-[7px] before:border-y-transparent"
             >
               <article className="bg-background/90 dark:bg-foreground/5 backdrop-blur-xl border border-primary/30 rounded-xl p-6 shadow-2xl/25">
                 <h3 className="text-xl font-semibold text-foreground">{exp.title}</h3>


### PR DESCRIPTION
## Summary
- add "Experiencia" heading and reposition timeline line
- center timeline nodes and offset cards for better layout
- increase item spacing for consistent separation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688df60e1884832c8180a268c21c3966