### PR TITLE
Center mobile layout for key sections

### DIFF
--- a/my-personal-site/app/page.tsx
+++ b/my-personal-site/app/page.tsx
@@ -10,7 +10,7 @@ import ParallaxSection from '../components/ParallaxSection';
 
 export default function Home() {
   return (
-    <main className="flex flex-col items-center">
+    <main className="flex flex-col items-center px-0">
       <Header />
       <Hero />
       <ParallaxSection>

--- a/my-personal-site/components/About.tsx
+++ b/my-personal-site/components/About.tsx
@@ -1,8 +1,8 @@
 export default function About() {
   return (
-    <section id="about" className="max-w-2xl mx-auto px-4 py-20 text-center">
+    <section id="about" className="max-w-2xl mx-auto px-6 text-center py-24">
       <h2 className="text-3xl font-semibold mb-4">Acerca de mí</h2>
-      <p className="mb-4">
+      <p className="mb-4 text-center">
         Soy Ingeniero en Informática y en Ingeniería Técnica de Sistemas. A lo largo
         de mi trayectoria he evolucionado hacia el liderazgo técnico, coordinando
         equipos de desarrollo y dirigiendo grandes proyectos de software. Domino

--- a/my-personal-site/components/Education.tsx
+++ b/my-personal-site/components/Education.tsx
@@ -21,7 +21,7 @@ export default function Education() {
   ];
 
   return (
-    <section id="education" className="max-w-3xl mx-auto px-4 py-20">
+    <section id="education" className="max-w-3xl mx-auto px-6 text-center py-20">
       <h2 className="text-3xl font-semibold text-center mb-8">Educación</h2>
       <ul className="space-y-6">
         {studies.map((study) => (

--- a/my-personal-site/components/ExperienceTimeline.tsx
+++ b/my-personal-site/components/ExperienceTimeline.tsx
@@ -6,10 +6,10 @@ import { experiences } from '@/data/experience';
 export default function ExperienceTimeline() {
   return (
     <section id="experience" className="relative py-24 bg-gradient-to-b from-background via-background/70 to-background">
-      <h2 className="text-3xl md:text-4xl font-bold text-center text-foreground mb-16">
+      <h2 className="mx-auto text-center text-3xl md:text-4xl font-bold text-foreground mb-16">
         Experiencia
       </h2>
-      <div className="relative max-w-3xl mx-auto flex flex-col gap-28 px-6">
+      <div className="relative max-w-3xl mx-auto flex flex-col gap-28 px-6 md:px-0">
         {/* Línea central */}
         <motion.div
           className="absolute left-1/2 -translate-x-1/2 top-0 w-[2px] h-full bg-primary origin-top"
@@ -39,12 +39,12 @@ export default function ExperienceTimeline() {
               glareMaxOpacity={0.15}
               className="ml-10 md:ml-14 before:absolute before:left-[-7px] before:top-5 before:border-l-[7px] before:border-l-primary before:border-y-[7px] before:border-y-transparent"
             >
-              <article className="bg-background/90 dark:bg-foreground/5 backdrop-blur-xl border border-primary/30 rounded-xl p-6 shadow-2xl/25">
-                <h3 className="text-xl font-semibold text-foreground">{exp.title}</h3>
-                <p className="italic text-primary">{exp.company}</p>
-                <p className="mt-2 text-foreground/90">{exp.description}</p>
-                <p className="mt-1 text-sm text-foreground/70">{exp.date}</p>
-              </article>
+                <article className="text-left md:text-left bg-background/90 dark:bg-foreground/5 backdrop-blur-xl border border-primary/30 rounded-xl p-6 shadow-2xl/25">
+                  <h3 className="text-xl font-semibold text-foreground">{exp.title}</h3>
+                  <p className="italic text-primary">{exp.company}</p>
+                  <p className="mt-2 text-foreground/90">{exp.description}</p>
+                  <p className="mt-1 text-sm text-foreground/70">{exp.date}</p>
+                </article>
             </Tilt>
           </motion.div>
         ))}

--- a/my-personal-site/components/Hero.tsx
+++ b/my-personal-site/components/Hero.tsx
@@ -19,18 +19,20 @@ export default function Hero() {
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.6 }}
     >
-      <h1 className="text-5xl md:text-6xl font-bold mb-4">Hola, soy Antonio Hernández Cervantes</h1>
-      <h2 className="text-2xl md:text-3xl mb-2">Líder Técnico y experto en integración de IA</h2>
-      <p className="text-xl md:text-2xl mb-6">
-        <span>{text}</span>
-        <Cursor cursorStyle="|" />
-      </p>
-      <button
-        className="px-6 py-3 bg-foreground text-background rounded hover:opacity-80 transition"
-        onClick={() => document.getElementById('about')?.scrollIntoView({ behavior: 'smooth' })}
-      >
-        Conóceme
-      </button>
+      <div className="max-w-lg mx-auto text-center space-y-6">
+        <h1 className="text-5xl md:text-6xl font-bold">Hola, soy Antonio Hernández Cervantes</h1>
+        <h2 className="text-2xl md:text-3xl">Líder Técnico y experto en integración de IA</h2>
+        <p className="text-xl md:text-2xl">
+          <span>{text}</span>
+          <Cursor cursorStyle="|" />
+        </p>
+        <button
+          className="mx-auto px-6 py-3 bg-foreground text-background rounded hover:opacity-80 transition"
+          onClick={() => document.getElementById('about')?.scrollIntoView({ behavior: 'smooth' })}
+        >
+          Conóceme
+        </button>
+      </div>
     </motion.section>
   );
 }

--- a/my-personal-site/components/Skills.tsx
+++ b/my-personal-site/components/Skills.tsx
@@ -15,7 +15,7 @@ export default function Skills() {
   ];
 
   return (
-    <section id="skills" className="max-w-3xl mx-auto px-4 py-20">
+    <section id="skills" className="max-w-3xl mx-auto px-6 text-center py-20">
       <h2 className="text-3xl font-semibold text-center mb-8">Habilidades</h2>
       <div className="space-y-6">
         {skills.map((skill) => (


### PR DESCRIPTION
## Summary
- Center hero text and CTA with new container and button alignment
- Tighten section wrappers for About, Experience, Education, and Skills to ensure mobile centering
- Remove global padding from main layout so individual sections control their own spacing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688df8eb43d0832c985b72e6f65ae7e0