### PR TITLE
Fix hero image not displayed in static export

### DIFF
--- a/my-personal-site/components/Hero.tsx
+++ b/my-personal-site/components/Hero.tsx
@@ -25,7 +25,7 @@ export default function Hero() {
           {/* glow animado opcional */}
           <span className="absolute inset-0 rounded-full bg-primary/20 blur-xl animate-pulse"></span>
           <Image
-            src="/images/foto_antonio.jpeg"
+            src="images/foto_antonio.jpeg"
             alt="Antonio Hernández Cervantes"
             fill
             sizes="160px"

--- a/my-personal-site/next.config.ts
+++ b/my-personal-site/next.config.ts
@@ -4,6 +4,15 @@ const nextConfig: NextConfig = {
   output: 'export',
   basePath: '/antoniohc',
   assetPrefix: '/antoniohc',
+  images: {
+    unoptimized: true,
+    localPatterns: [
+      {
+        pathname: '/images/**',
+        search: '',
+      },
+    ],
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- configure Next.js images with local path pattern and disable optimization for static export
- reference hero photo using a relative path so basePath is honored

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688f1edb658c832ca1250c9cfedadaa8